### PR TITLE
Store @child_pid value

### DIFF
--- a/lib/safe_timeout/interrupting_child_process.rb
+++ b/lib/safe_timeout/interrupting_child_process.rb
@@ -8,10 +8,13 @@ module SafeTimeout
 
     def start(&block)
       Signal.trap("TRAP", &@on_timeout)
-      Kernel.fork { wait_for_expiration }
+      @child_pid = Kernel.fork { wait_for_expiration }
       yield
     ensure
-      stop rescue nil
+      begin
+        stop
+      rescue Errno::ESRCH
+      end
     end
 
     def stop


### PR DESCRIPTION
Currently it seems we're trying to kill @child_pid which doesn't exist. The problem seems to be just masked by the rescue nil construct.

I made the rescue more explicit to avoid masking potential problems in the future as well.
